### PR TITLE
fix: include svg files to appear when filtering for images

### DIFF
--- a/backend/storage/local_storage.py
+++ b/backend/storage/local_storage.py
@@ -94,7 +94,7 @@ class LocalStorage:
         Returns:
             List of file metadata dicts
         """
-        image_extensions = {'.jpg', '.jpeg', '.png', '.gif', '.webp'}
+        image_extensions = {'.jpg', '.jpeg', '.png', '.gif', '.webp','.svg'}
         files = []
         
         if self.local_dir.exists():


### PR DESCRIPTION
### Fix SVG image filtering inconsistency

SVG files were treated as images during upload but excluded when filtering images in `list_files`.

#### Changes
- Added `.svg` to image extension checks
- Ensures consistent behavior between upload and listing

Fixes #<8>
