### PR TITLE
Replace hardcoded salt in PBKDF2 key derivation

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -2,3 +2,8 @@ MONGODB_URI=mongodb://mongo:27017
 DB_NAME=portfolio
 JWT_SECRET_KEY=random-string-at-32-chars
 CORS_ORIGINS=http://localhost:3000
+
+# Encryption salt for PBKDF2 key derivation (used to encrypt TOTP secrets, etc.)
+# REQUIRED for new deployments. Generate with: python -c "import secrets; print(secrets.token_urlsafe(32))"
+# WARNING: Changing this after data has been encrypted will make existing encrypted data unrecoverable.
+ENCRYPTION_SALT=generate-a-unique-random-string-here


### PR DESCRIPTION
## Summary
Fixes #7

The cryptographic salt used in PBKDF2 key derivation was hardcoded in source code, meaning every deployment shared the same salt value.

## Changes
| File | Change |
|------|--------|
| `backend/utils/crypto.py` | Read salt from `ENCRYPTION_SALT` env var with legacy fallback |
| `backend/.env.example` | Add `ENCRYPTION_SALT` with generation instructions |

## Migration Guide
**Existing deployments:** No action needed immediately, the code falls back to the legacy salt and logs a warning. To upgrade:

1. Generate a salt: `python -c "import secrets; print(secrets.token_urlsafe(32))"`
2. Re-encrypt any existing TOTP secrets with the new salt
3. Set `ENCRYPTION_SALT` in your `.env`

**New deployments:** Set `ENCRYPTION_SALT` before first run.